### PR TITLE
Close #11 GCPの設定

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,2 @@
+runtime: nodejs12
+instance_class: F1

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ app.post('/', (req, res) => {
     const isCorrectAnswer = function (question, user_answer) {
         return new Promise((resolve, reject) => {
             const error = new ReferenceError();
-            const AnswerData = JSON.parse(fs.readFileSync('')); // 解答のファイルパスを渡す(json)
+            const AnswerData = JSON.parse(fs.readFileSync('data/answers.json')); // 解答のファイルパスを渡す(json)
 
             if (AnswerData.answers[question]) { //渡されたインデックスの問題があるか確認する
                 resolve(AnswerData.answers[question] === user_answer); //正答ならtrue、誤答ならfalseを渡して実行する
@@ -34,7 +34,7 @@ app.post('/', (req, res) => {
             }
             console.log(judgeResult);
             if (judgeResult) {// 正解の時だけjsonを加工する
-                const UrlData = JSON.parse(fs.readFileSync('')); //URLのデータが入ってるjsonファイルを渡す
+                const UrlData = JSON.parse(fs.readFileSync('data/url.json')); //URLのデータが入ってるjsonファイルを渡す
                 responceJson.isCorrect = true;
                 responceJson.url_snippet = UrlData.url[req.body.question];
             }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Capture The Toyota(for 2020s Koyo Fes)",
   "main": "index.js",
   "scripts": {
+    "start":"node index.js",
     "test": "node index.js"
   },
   "repository": {


### PR DESCRIPTION
・GCPは起動コマンドを設定しないと"npm start"を使用するので、npm startの内容を記述しました。
・GCPの設定ファイル、"app.yaml"を追加しました。
・index.jsに回答ファイルのパスを渡しました。